### PR TITLE
Insert spaces for duplicate capitals

### DIFF
--- a/memegen/domain/text.py
+++ b/memegen/domain/text.py
@@ -51,16 +51,27 @@ class Text:
 
     @staticmethod
     def _format_line(part):
+        part = list(part)
         chars = []
 
         previous_upper = True
-        for char in part:
+        for i, char in enumerate(part):
             if char in ('_', '-'):
                 chars.append(' ')
             else:
                 if char.isupper():
                     if not previous_upper and chars[-1] != ' ':
                         chars.append(' ')
+                    else:
+                        letters_to_check = part[max(i - 1, 0):i + 2]
+
+                        if len(letters_to_check) == 3:
+                            if (
+                                letters_to_check[0].isupper() and
+                                letters_to_check[1].isupper() and
+                                letters_to_check[2].islower()
+                            ):
+                                chars.append(' ')
 
                 chars.append(char.upper())
                 previous_upper = char.isupper()

--- a/memegen/domain/text.py
+++ b/memegen/domain/text.py
@@ -57,11 +57,11 @@ class Text:
         for char in part:
             if char in ('_', '-'):
                 chars.append(' ')
-                previous_upper = True
             else:
                 if char.isupper():
                     if not previous_upper and chars[-1] != ' ':
                         chars.append(' ')
+
                 chars.append(char.upper())
                 previous_upper = char.isupper()
 

--- a/memegen/test/test_domain_text.py
+++ b/memegen/test/test_domain_text.py
@@ -58,6 +58,10 @@ class TestText:
         text = Text("  hello  World /    ")
         assert ["HELLO  WORLD"] == text.lines
 
+    def test_duplicate_capitals_treated_as_spaces(self):
+        text = Text("IWantTHISPattern_to-Work")
+        assert ["I WANT THIS PATTERN TO WORK"] == text.lines
+
     def test_path(self):
         text = Text("hello/World")
         assert "hello/world" == text.path
@@ -81,3 +85,7 @@ class TestText:
     def test_path_with_a_single_underscore(self):
         text = Text(" _     ")
         assert "_" == text.path
+
+    def test_path_with_duplicate_capitals(self):
+        text = Text("IWantTHISPattern_to-Work")
+        assert "i-want-this-pattern-to-work" == text.path

--- a/memegen/test/test_domain_text.py
+++ b/memegen/test/test_domain_text.py
@@ -42,7 +42,7 @@ class TestText:
         text = Text("helloWorld")
         assert ["HELLO WORLD"] == text.lines
 
-    def test_lines_kepp_spaces(self):
+    def test_lines_keep_spaces(self):
         text = Text("hello world")
         assert ["HELLO WORLD"] == text.lines
 


### PR DESCRIPTION
If we encounter the pattern "ABc" in a string, we want to insert a space between "A" and "B".

