### PR TITLE
Only validate links once per machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ docs/*.png
 .coverage
 htmlcov
 pyunit.xml
+*.tmp
 
 # Build and release directories
 build

--- a/Makefile
+++ b/Makefile
@@ -274,6 +274,7 @@ clean-all: clean clean-env .clean-workspace
 
 .PHONY: .clean-test
 .clean-test:
+	find data -name '*.tmp' -delete
 	rm -rf .pytest .coverage htmlcov
 
 .PHONY: .clean-dist

--- a/memegen/test/test_services_template.py
+++ b/memegen/test/test_services_template.py
@@ -63,3 +63,12 @@ class TestTemplateService:
 
         with patch('os.path.isfile', Mock(return_value=True)):
             assert False is template_service.validate()
+
+    def test_validate_link(self, template_service):
+        templates = [Template(key='abc',
+                              name="The ABC Meme",
+                              link="example.com")]
+        template_service.template_store.filter.return_value = templates
+
+        with patch('os.path.isfile', Mock(return_value=True)):
+            assert True is template_service.validate()


### PR DESCRIPTION
This should still check links on the CI server.

Fixes #74 