### PR TITLE
Get tracker ID from environment var instead of hard-coding it

### DIFF
--- a/memegen/routes/image.py
+++ b/memegen/routes/image.py
@@ -58,7 +58,7 @@ def get_encoded(code):
 def track_request(title):
     data = dict(
         v=1,
-        tid='UA-6468614-10',
+        tid=app.config['GOOGLE_ANALYTICS_TID'],
         cid=request.remote_addr,
 
         t='pageview',

--- a/memegen/routes/root.py
+++ b/memegen/routes/root.py
@@ -1,11 +1,24 @@
 from collections import OrderedDict
 
-from flask import Blueprint, url_for
+from flask import Blueprint, url_for, current_app, render_template, Response
 
 from ._common import GITHUB_BASE, CONTRIBUTING
 
 
-blueprint = Blueprint('root', __name__, url_prefix="/")
+blueprint = Blueprint('root', __name__, url_prefix="/",
+                      template_folder='../templates')
+
+
+@blueprint.route("")
+def get_index():
+    tid = current_app.config['GOOGLE_ANALYTICS_TID']
+    return Response(render_template("index.html", ga_tid=tid))
+
+
+@blueprint.route("flask-api/static/js/default.js")
+def get_javascript():
+    tid = current_app.config['GOOGLE_ANALYTICS_TID']
+    return render_template("js/default.js", ga_tid=tid)
 
 
 @blueprint.route("api")

--- a/memegen/routes/static.py
+++ b/memegen/routes/static.py
@@ -5,16 +5,6 @@ blueprint = Blueprint('static', __name__, url_prefix="/",
                       static_folder='../static')
 
 
-@blueprint.route("", endpoint='get')
-def get_index():
-    return blueprint.send_static_file("index.html")
-
-
 @blueprint.route("stylesheets/<name>.css")
 def get_css(name):
     return blueprint.send_static_file("stylesheets/{}.css".format(name))
-
-
-@blueprint.route("flask-api/static/js/default.js")
-def get_javascript():
-    return blueprint.send_static_file("js/default.js")

--- a/memegen/settings.py
+++ b/memegen/settings.py
@@ -12,6 +12,8 @@ class Config:
     DEBUG = False
     THREADED = False
 
+    GOOGLE_ANALYTICS_TID = os.getenv('GOOGLE_ANALYTICS_TID')
+
 
 class ProdConfig(Config):
 

--- a/memegen/templates/index.html
+++ b/memegen/templates/index.html
@@ -92,7 +92,7 @@
           </script>
           <script type="text/javascript">
             try {
-              var pageTracker = _gat._getTracker("UA-6468614-10");
+              var pageTracker = _gat._getTracker("{{ ga_tid }}");
             pageTracker._trackPageview();
             } catch(err) {}
           </script>

--- a/memegen/templates/js/default.js
+++ b/memegen/templates/js/default.js
@@ -61,5 +61,5 @@ if (selectedTab && selectedTab.length > 0) {
 m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-ga('create', 'UA-6468614-10', 'auto');
+ga('create', '{{ ga_tid }}', 'auto');
 ga('send', 'pageview');


### PR DESCRIPTION
Set `GOOGLE_ANALYTICS_TID` on Heroku once merged.