### PR TITLE
Update to Pillow 3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask == 0.10.1
 Flask-API == 0.6.4
 webargs == 1.0.0
-Pillow == 2.9.0
+Pillow == 3.0.0
 YORM == 0.5.0
 requests == 2.7.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask == 0.10.1
 Flask-API == 0.6.4
 webargs == 1.0.0
-Pillow == 3.0.0
+Pillow == 3.1.1
 YORM == 0.5.0
 requests == 2.7.0
 


### PR DESCRIPTION
Had a lot of trouble trying to get the jpeg encoder to work in Pillow.  It looks like it was an install issue, but I could not get it to work in v2.9.  I found that [v3.0 requires the jpeg lib when installed](https://github.com/python-pillow/Pillow/issues/1275#issuecomment-147430993) so I've updated the requirements file.