### PR TITLE
Add postgreSQL to contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@
     * Windows: https://www.python.org/downloads
     * Mac: `$ brew install python3`
     * Linux: `python3.5` and `python3.5-dev` packages
+* PostgreSQL
+    * Windows: http://www.postgresql.org/download/windows/
+    * Mac: `$ brew install postgresql && brew services start postgresql`
+    * Linux: http://www.postgresql.org/download/
 * Make:
     * Windows: http://cygwin.com/install.html
     * Mac: https://developer.apple.com/xcode


### PR DESCRIPTION
Not sure what exact version is required, but I noticed that postgreSQL was missing from the contributing document when I ran into this issue myself.