### PR TITLE
Remove 'date' metadata from the API root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision History
 
+## 3.0
+
+- Removed `'date'` key from `/api`.
+
 ## 2.3
 
 - Added support for custom fonts: `/custom/test.jpg?font=impact`

--- a/memegen/__init__.py
+++ b/memegen/__init__.py
@@ -3,7 +3,7 @@
 import sys
 
 __project__ = 'MemeGen'
-__version__ = '2.3'
+__version__ = '3.0'
 
 VERSION = "{} v{}".format(__project__, __version__)
 

--- a/memegen/routes/root.py
+++ b/memegen/routes/root.py
@@ -1,4 +1,3 @@
-import os
 from collections import OrderedDict
 
 from flask import Blueprint
@@ -20,7 +19,6 @@ def get():
     data['aliases'] = route('aliases.get', _external=True)
     data['magic'] = route('magic.get', _external=True)
     data['version'] = __version__
-    data['date'] = os.getenv('DEPLOY_DATE')
     data['changes'] = CHANGES_URL
     return data
 

--- a/tests/test_routes_root.py
+++ b/tests/test_routes_root.py
@@ -7,9 +7,7 @@ from .utilities import load
 
 def describe_root():
 
-    def it_returns_links_and_metadata(client, monkeypatch):
-        monkeypatch.setenv('DEPLOY_DATE', "<now>")
-
+    def it_returns_links_and_metadata(client):
         status, data = load(client.get("/api"))
 
         expect(status) == 200
@@ -18,7 +16,6 @@ def describe_root():
             'fonts': "http://localhost/api/fonts/",
             'aliases': "http://localhost/aliases/",
             'magic': "http://localhost/magic/",
-            'version': "2.3",
-            'date': "<now>",
+            'version': "3.0",
             'changes': "https://raw.githubusercontent.com/jacebrowning/memegen/master/CHANGELOG.md"
         }


### PR DESCRIPTION
The value of this property was not reliable and it added extra code to manage.