### PR TITLE
Changed image file extension so Pillow will use the same format as ba…

### DIFF
--- a/memegen/domain/image.py
+++ b/memegen/domain/image.py
@@ -30,9 +30,9 @@ class Image:
         base = os.path.join(self.root, self.template.key, self.text.path)
 
         if self.style or self.font:
-            return "{}#{}.jpg".format(base, sha.hexdigest())
+            return "{}#{}.img".format(base, sha.hexdigest())
         else:
-            return base + ".jpg"
+            return base + ".img"
 
     def generate(self):
         directory = os.path.dirname(self.path)
@@ -92,7 +92,7 @@ def make_meme(top, bottom, font, background, path, match_font_size=False):
                         bottom, bottom_font, bottom_font_size)
 
     log.info("Generating image: %s", path)
-    return img.save(path)
+    return img.save(path, format=img.format)
 
 
 def _draw_outlined_text(draw_image, text_position, text, font, font_size):

--- a/tests/test_routes_image.py
+++ b/tests/test_routes_image.py
@@ -17,7 +17,7 @@ def describe_get():
     def describe_visible():
 
         def with_nominal_text(client):
-            path = os.path.join(IMAGES, 'iw', 'hello', 'world' + '.jpg')
+            path = os.path.join(IMAGES, 'iw', 'hello', 'world' + '.img')
             if os.path.exists(path):
                 os.remove(path)
 


### PR DESCRIPTION
…ckground image

This should resolve issue #238 as long as its ok to serve a jpg file that may actually be a png file. Chrome and Firefox display it correctly. If you save it locally the browser will use the jpg extension and image viewers (like Eye of Gnome) give up if the extension doesn't match the actual file type.