### PR TITLE
Clear cache when invalid

### DIFF
--- a/memegen/routes/_cache.py
+++ b/memegen/routes/_cache.py
@@ -40,6 +40,11 @@ class Cache:
         except IndexError:
             data = {}
 
+        if not isinstance(data, dict):
+            log.error("Invalid cache")
+            self.items = []
+            data = {}
+
         log.info("Retrieved cache: %s", data)
 
         return data


### PR DESCRIPTION
Fixes: `TypeError · 'str' object does not support item assignment`