### PR TITLE
Fix swagger validation errors

### DIFF
--- a/app/api/images.py
+++ b/app/api/images.py
@@ -13,6 +13,11 @@ blueprint = Blueprint("images", url_prefix="/images")
 @blueprint.get("/")
 @doc.summary("List sample memes")
 @doc.operation("images.list")
+@doc.produces(
+    [{"url": str, "template": str}],
+    description="Successfully returned a list of sample memes",
+    content_type="application/json",
+)
 async def index(request):
     loop = asyncio.get_event_loop()
     samples = await loop.run_in_executor(None, helpers.get_sample_images, request)
@@ -30,6 +35,16 @@ async def index(request):
     ),
     content_type="application/json",
     location="body",
+)
+@doc.response(
+    201,
+    {"url": str},
+    description="Successfully created a meme",
+)
+@doc.response(
+    400,
+    {"error": str},
+    description='Required "template_key" missing in request body',
 )
 async def create(request):
     if request.form:

--- a/app/api/images.py
+++ b/app/api/images.py
@@ -12,6 +12,7 @@ blueprint = Blueprint("images", url_prefix="/images")
 
 @blueprint.get("/")
 @doc.summary("List sample memes")
+@doc.operation("images.list")
 async def index(request):
     loop = asyncio.get_event_loop()
     samples = await loop.run_in_executor(None, helpers.get_sample_images, request)
@@ -22,6 +23,7 @@ async def index(request):
 
 @blueprint.post("/")
 @doc.summary("Create a meme from a template")
+@doc.operation("images.create")
 @doc.consumes(
     doc.JsonBody(
         {"template_key": str, "text_lines": [str], "extension": str, "redirect": bool}

--- a/app/api/images.py
+++ b/app/api/images.py
@@ -26,6 +26,7 @@ async def index(request):
     doc.JsonBody(
         {"template_key": str, "text_lines": [str], "extension": str, "redirect": bool}
     ),
+    content_type="application/json",
     location="body",
 )
 async def create(request):

--- a/app/api/images.py
+++ b/app/api/images.py
@@ -14,7 +14,7 @@ blueprint = Blueprint("images", url_prefix="/images")
 @doc.summary("List sample memes")
 @doc.operation("images.list")
 @doc.produces(
-    [{"url": str, "template": str}],
+    doc.List({"url": str, "template": str}),
     description="Successfully returned a list of sample memes",
     content_type="application/json",
 )
@@ -36,16 +36,8 @@ async def index(request):
     content_type="application/json",
     location="body",
 )
-@doc.response(
-    201,
-    {"url": str},
-    description="Successfully created a meme",
-)
-@doc.response(
-    400,
-    {"error": str},
-    description='Required "template_key" missing in request body',
-)
+@doc.response(201, {"url": str}, description="Successfully created a meme")
+@doc.response(400, {"error": str}, description='Required "template_key" missing in request body')
 async def create(request):
     if request.form:
         payload = dict(request.form)
@@ -76,18 +68,43 @@ async def create(request):
 
 @blueprint.get("/<template_key>.png")
 @doc.summary("Display a template background")
+@doc.produces(
+    doc.File(),
+    description="Successfully displayed a template background",
+    content_type="image/png",
+)
+@doc.response(404, doc.File(), description="Template not found")
+@doc.response(415, doc.File(), description="Unable to download image URL")
+@doc.response(422, doc.File(), description="Invalid style for template or no image URL specified for custom template")
 async def blank_png(request, template_key):
     return await render_image(request, template_key, ext="png")
 
 
 @blueprint.get("/<template_key>.jpg")
 @doc.summary("Display a template background")
+@doc.produces(
+    doc.File(),
+    description="Successfully displayed a template background",
+    content_type="image/jpeg",
+)
+@doc.response(404, doc.File(), description="Template not found")
+@doc.response(415, doc.File(), description="Unable to download image URL")
+@doc.response(422, doc.File(), description="Invalid style for template or no image URL specified for custom template")
 async def blank_jpg(request, template_key):
     return await render_image(request, template_key, ext="jpg")
 
 
 @blueprint.get("/<template_key>/<text_paths:[\s\S]+>.png")
 @doc.summary("Display a custom meme")
+@doc.produces(
+    doc.File(),
+    description="Successfully displayed a custom meme",
+    content_type="image/png",
+)
+@doc.response(404, doc.File(), description="Template not found")
+@doc.response(414, doc.File(), description="Custom text too long (length >200)")
+@doc.response(415, doc.File(), description="Unable to download image URL")
+@doc.response(422, doc.File(), description="Invalid style for template or no image URL specified for custom template")
 async def text_png(request, template_key, text_paths):
     slug, updated = utils.text.normalize(text_paths)
     if updated:
@@ -103,6 +120,15 @@ async def text_png(request, template_key, text_paths):
 
 @blueprint.get("/<template_key>/<text_paths:[\s\S]+>.jpg")
 @doc.summary("Display a custom meme")
+@doc.produces(
+    doc.File(),
+    description="Successfully displayed a custom meme",
+    content_type="image/jpeg",
+)
+@doc.response(404, doc.File(), description="Template not found")
+@doc.response(414, doc.File(), description="Custom text too long (length >200)")
+@doc.response(415, doc.File(), description="Unable to download image URL")
+@doc.response(422, doc.File(), description="Invalid style for template or no image URL specified for custom template")
 async def text_jpg(request, template_key, text_paths):
     slug, updated = utils.text.normalize(text_paths)
     if updated:

--- a/app/api/shortcuts.py
+++ b/app/api/shortcuts.py
@@ -10,6 +10,9 @@ blueprint = Blueprint("shortcuts", url_prefix="/")
 
 @blueprint.get("/images/<template_key>")
 @doc.summary("Redirect to a sample image")
+@doc.response(302, doc.File(), description="Successfully redirected to a sample image")
+@doc.response(404, str, description="Template not found")
+@doc.response(501, str, description="Template not fully implemented")
 async def sample(request, template_key):
     if settings.DEBUG:
         template = models.Template.objects.get_or_create(template_key)
@@ -32,6 +35,8 @@ async def sample(request, template_key):
 @blueprint.get("/<template_key>.png")
 @doc.summary("Redirect to a sample image")
 @doc.exclude(settings.DEPLOYED)
+@doc.response(302, doc.File(), description="Successfully redirected to a sample image")
+@doc.response(404, str, description="Template not found")
 async def sample_png(request, template_key):
     template = models.Template.objects.get_or_none(template_key)
     if template:
@@ -43,6 +48,8 @@ async def sample_png(request, template_key):
 @blueprint.get("/<template_key>.jpg")
 @doc.summary("Redirect to a sample image")
 @doc.exclude(settings.DEPLOYED)
+@doc.response(302, doc.File(), description="Successfully redirected to a sample image")
+@doc.response(404, str, description="Template not found")
 async def sample_jpg(request, template_key):
     template = models.Template.objects.get_or_none(template_key)
     if template:
@@ -54,12 +61,19 @@ async def sample_jpg(request, template_key):
 @blueprint.get("/<template_key>")
 @doc.summary("Redirect to a sample image")
 @doc.exclude(settings.DEPLOYED)
+@doc.response(302, doc.File(), description="Successfully redirected to a sample image")
 async def sample_legacy(request, template_key):
     return response.redirect(f"/images/{template_key}")
 
 
 @blueprint.get("/images/<template_key>/<text_paths:[\s\S]+>")
 @doc.summary("Redirect to a custom image")
+@doc.produces(
+    str,
+    description="Successfully displayed a custom meme",
+    content_type="text/html",
+)
+@doc.response(302, doc.File(), description="Successfully redirected to a custom image")
 async def custom(request, template_key, text_paths):
     if not settings.DEBUG:
         url = request.app.url_for(
@@ -79,6 +93,8 @@ async def custom(request, template_key, text_paths):
 @blueprint.get("/<template_key>/<text_paths:[\s\S]+>.png")
 @doc.summary("Redirect to a custom image")
 @doc.exclude(settings.DEPLOYED)
+@doc.response(302, doc.File(), description="Successfully redirected to a custom image")
+@doc.response(404, str, description="Template not found")
 async def custom_png(request, template_key, text_paths):
     template = models.Template.objects.get_or_none(template_key)
     if template:
@@ -92,6 +108,8 @@ async def custom_png(request, template_key, text_paths):
 @blueprint.get("/<template_key>/<text_paths:[\s\S]+>.jpg")
 @doc.summary("Redirect to a custom image")
 @doc.exclude(settings.DEPLOYED)
+@doc.response(302, doc.File(), description="Successfully redirected to a custom image")
+@doc.response(404, str, description="Template not found")
 async def custom_jpg(request, template_key, text_paths):
     template = models.Template.objects.get_or_none(template_key)
     if template:
@@ -105,5 +123,6 @@ async def custom_jpg(request, template_key, text_paths):
 @blueprint.get("/<template_key>/<text_paths:[\s\S]+>")
 @doc.summary("Redirect to a custom image")
 @doc.exclude(settings.DEPLOYED)
+@doc.response(302, doc.File(), description="Successfully redirected to a custom image")
 async def custom_legacy(request, template_key, text_paths):
     return response.redirect(f"/images/{template_key}/{text_paths}")

--- a/app/api/templates.py
+++ b/app/api/templates.py
@@ -34,6 +34,7 @@ async def detail(request, key):
     doc.JsonBody(
         {"image_url": str, "text_lines": [str], "extension": str, "redirect": bool}
     ),
+    content_type="application/json",
     location="body",
 )
 async def custom(request):
@@ -61,6 +62,7 @@ async def custom(request):
 @doc.summary("Create a meme from a template")
 @doc.consumes(
     doc.JsonBody({"text_lines": [str], "extension": str, "redirect": bool}),
+    content_type="application/json",
     location="body",
 )
 async def build(request, key):

--- a/app/api/templates.py
+++ b/app/api/templates.py
@@ -21,6 +21,7 @@ async def index(request):
 
 @blueprint.get("/<key>")
 @doc.summary("View a specific template")
+@doc.operation("templates.detail")
 async def detail(request, key):
     template = Template.objects.get_or_none(key)
     if template:
@@ -60,6 +61,7 @@ async def custom(request):
 
 @blueprint.post("/<key>")
 @doc.summary("Create a meme from a template")
+@doc.operation("templates.create")
 @doc.consumes(
     doc.JsonBody({"text_lines": [str], "extension": str, "redirect": bool}),
     content_type="application/json",

--- a/app/api/templates.py
+++ b/app/api/templates.py
@@ -13,6 +13,20 @@ blueprint = Blueprint("templates", url_prefix="/templates")
 
 @blueprint.get("/")
 @doc.summary("List all templates")
+@doc.produces(
+    # Can't use doc.List(Template) because the jsonify method is slightly different
+    doc.List({
+        "name": str,
+        "key": str,
+        "styles": doc.List(str),
+        "blank": str,
+        "sample": str,
+        "source": str,
+        "_self": str,
+    }),
+    description="Successfully returned a list of all templates",
+    content_type="application/json",
+)
 async def index(request):
     loop = asyncio.get_event_loop()
     data = await loop.run_in_executor(None, helpers.get_valid_templates, request)
@@ -22,6 +36,20 @@ async def index(request):
 @blueprint.get("/<key>")
 @doc.summary("View a specific template")
 @doc.operation("templates.detail")
+@doc.produces(
+    {
+        "name": str,
+        "key": str,
+        "styles": doc.List(str),
+        "blank": str,
+        "sample": str,
+        "source": str,
+        "_self": str,
+    },
+    description="Successfully returned a specific templates",
+    content_type="application/json",
+)
+@doc.response(404, str, description="Template not found")
 async def detail(request, key):
     template = Template.objects.get_or_none(key)
     if template:
@@ -38,6 +66,7 @@ async def detail(request, key):
     content_type="application/json",
     location="body",
 )
+@doc.response(201, {"url": str}, description="Successfully created a meme from a custom image")
 async def custom(request):
     if request.form:
         payload = dict(request.form)
@@ -67,6 +96,7 @@ async def custom(request):
     content_type="application/json",
     location="body",
 )
+@doc.response(201, {"url": str}, description="Successfully created a meme from a template")
 async def build(request, key):
     if request.form:
         payload = dict(request.form)

--- a/app/tests/test_docs.py
+++ b/app/tests/test_docs.py
@@ -7,3 +7,69 @@ def describe_spec():
         request, response = client.get("/docs/swagger.json")
         expect(response.status) == 200
         expect(response.json["info"]["version"]) == version
+
+    def describe_image_list():
+        # Only spot checking the POST /images route, not sure
+        # how valuable it would be to check the rest exhaustively?
+        def it_contains_the_operation_id(expect, client):
+            request, response = client.get("/docs/swagger.json")
+            # This is our custom operationId, the default was images.index
+            expect(response.json["paths"]["/images"]["post"]["operationId"]) == "images.create"
+
+        def it_contains_the_request_spec(expect, client):
+            request, response = client.get("/docs/swagger.json")
+            request_spec = response.json["paths"]["/images"]["post"]
+            expect(request_spec["consumes"]) == ["application/json"]
+            expect(request_spec["parameters"][0]) == {
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "template_key": {
+                            "type": "string"
+                        },
+                        "text_lines": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "extension": {
+                            "type": "string"
+                        },
+                        "redirect": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "name": "body",
+                "required": False,
+                "in": "body"
+            }
+
+        def it_contains_the_response_spec(expect, client):
+            request, response = client.get("/docs/swagger.json")
+            response_spec = response.json["paths"]["/images"]["post"]["responses"]
+            # Successful response
+            expect(response_spec["201"]["description"]) == (
+                "Successfully created a meme"
+            )
+            expect(response_spec["201"]["schema"]) == {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string"
+                    },
+                }
+            }
+            # Error response
+            expect(response_spec["400"]["description"]) == (
+                'Required "template_key" missing in request body'
+            )
+            expect(response_spec["400"]["schema"]) == {
+                "type": "object",
+                "properties": {
+                    "error": {
+                        "type": "string"
+                    },
+                }
+            }


### PR DESCRIPTION
I believe these changes should be enough to close #509 . Ran through the validator again and it's all green now :+1: 

Fixed:
* "*consumes. is not of type `string`" by specifying `content_type` in `@doc.consumes` (although it would be nice if `sanic_openapi` did that automatically
* "*200.description is missing" by specifying the `@doc.produces` description for the default 200 responses
* "*operationId is repeated" by specifying the `@doc.operation` ID to overwrite the default which was being duplicated

Also attempted to update the unit test coverage, although only for one representative route. Let me know if you'd like me to do all the routes comprehensively though.

Cheers,
Kyle
