### PR TITLE
Try portray docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,8 @@
-# Setup
+# Contributing
 
-## Requirements
+## Setup
+
+### Requirements
 
 * Make:
     * macOS: `$ xcode-select --install`
@@ -15,7 +17,7 @@ To confirm these system dependencies are configured correctly:
 $ make doctor
 ```
 
-## Installation
+### Installation
 
 Install project dependencies into a virtual environment:
 
@@ -23,13 +25,15 @@ Install project dependencies into a virtual environment:
 $ make install
 ```
 
-# Local Development
+## Local Development
 
 To start the API server:
 
 ```text
 $ make run
 ```
+
+### Adding a Template
 
 To add a new meme template:
 
@@ -38,9 +42,9 @@ To add a new meme template:
 3. Update `config.yml` in the `templates` directory
 4. Refresh `/images/<my_new_template_key>` to see the sample meme
 
-# Continuous Integration
+## Continuous Integration
 
-## Manual
+### Manual
 
 Run the tests:
 
@@ -54,7 +58,7 @@ Run static analysis:
 $ make check
 ```
 
-## Automatic
+### Automatic
 
 Keep all of the above tasks running on change:
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,12 @@ watch: install
 	@ sleep 2 && touch */__init__.py &
 	@ poetry run watchmedo shell-command --recursive --pattern="*.py;*.yml" --command="clear && make test check format SKIP_SLOW=true && echo && echo ✅ && echo" --wait --drop
 
+.PHONY: docs
+docs: install
+	poetry run portray in_browser --overwrite
+# 	Alternatively, only generate the static files without opening a browser
+# 	poetry run portray as_html --overwrite
+
 ###############################################################################
 # Delivery Tasks
 
@@ -117,3 +123,5 @@ promote: install
 	heroku pipelines:promote --app memegen-staging --to memegen-production
 	@ echo
 	SITE=https://api.memegen.link poetry run pytest scripts/check_deployment.py --verbose --no-cov --reruns=2
+# 	Update the documentation
+	poetry run portray on_github_pages

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An API to programatically generate memes based solely on requested URLs.
 
 # Generating Images
 
-The API is stateless so URLs contain all the information necessary to generate meme images. For example, https://api.memegen.link/images/buzz/memes/memes_everywhere.png produces:
+The API is stateless so URLs contain all the information necessary to generate meme images. For example, <https://api.memegen.link/images/buzz/memes/memes_everywhere.png> produces:
 
 ![Sample Image](https://api.memegen.link/images/buzz/memes/memes_everywhere.png?&width=600)
 
@@ -32,7 +32,7 @@ Reserved URL characters can be include using escape patterns:
 - tilde + B (`~b`) → backslash (`\`)
 - 2 single quotes (`''`) → double quote (`"`)
 
-For example, https://api.memegen.link/images/doge/~hspecial_characters~q/underscore__-dash--.png produces:
+For example, <https://api.memegen.link/images/doge/~hspecial_characters~q/underscore__-dash--.png> produces:
 
 ![Escaped Characters](https://api.memegen.link/images/doge/~hspecial_characters~q/underscore__-dash--.png?&width=600)
 
@@ -40,7 +40,7 @@ For example, https://api.memegen.link/images/doge/~hspecial_characters~q/undersc
 
 Some memes come in multiple forms, which can be selected via `?style=<style>`.
 
-For example, these are two styles provided by the https://api.memegen.link/templates/ds template:
+For example, these are two styles provided by the <https://api.memegen.link/templates/ds> template:
 
 |                   `/images/ds.png`                    |                   `/images/ds.png?style=maga`                    |
 | :---------------------------------------------------: | :--------------------------------------------------------------: |
@@ -48,7 +48,7 @@ For example, these are two styles provided by the https://api.memegen.link/templ
 
 ## Custom Backgrounds
 
-You can also use your own image URL as the background. For example, https://api.memegen.link/images/custom/_/my_background.png?background=http://www.gstatic.com/webp/gallery/1.png produces:
+You can also use your own image URL as the background. For example, <https://api.memegen.link/images/custom/_/my_background.png?background=http://www.gstatic.com/webp/gallery/1.png> produces:
 
 ![Custom Background](https://api.memegen.link/images/custom/_/my_background.png?background=http://www.gstatic.com/webp/gallery/1.png&width=600)
 
@@ -56,7 +56,7 @@ You can also use your own image URL as the background. For example, https://api.
 
 Images can be scaled to a specific width via `?width=<int>` or a specific height via `?height=<int>`. If both parameters are provided (`?width=<int>&height=<int>`), the image will be padded to the exact dimensions.
 
-For example, https://api.memegen.link/images/both/width_or_height/why_not_both~q.png?height=350&width=600 produces:
+For example, <https://api.memegen.link/images/both/width_or_height/why_not_both~q.png?height=350&width=600> produces:
 
 ![Custom Size](https://api.memegen.link/images/both/width_or_height/why_not_both~q.png?height=350&width=600)
 
@@ -68,23 +68,23 @@ If your client is going to show live previews of a custom meme, please use the `
 
 Both template keys and URLs are supported:
 
-- https://api.memegen.link/images/preview.jpg?template=fry&line[]=first&line[]=second
-- https://api.memegen.link/images/preview.jpg?template=https://api.memegen.link/images/fry.png&line[]=first&line[]=second
+- <https://api.memegen.link/images/preview.jpg?template=fry&line[]=first&line[]=second>
+- <https://api.memegen.link/images/preview.jpg?template=https://api.memegen.link/images/fry.png&line[]=first&line[]=second>
 
 # API Documentation
 
-The full interactive documentation is available here: https://api.memegen.link/docs/
+The full interactive API documentation is available here: <https://api.memegen.link/docs/>
 
 Here are some sample clients to explore:
 
-| Platforms  | Link                     | Source                                                                                |
-| :--------: | :----------------------- | :------------------------------------------------------------------------------------ |
-|   Slack    | ---                      | Python: [nicolewhite/slack-meme](https://github.com/nicolewhite/slack-meme)           | --- |
-|   Slack    | ---                      | Go: [CptSpaceToaster/slackbot](https://github.com/CptSpaceToaster/slackbot)           | --- |
-|   Slack    | http://www.memetizer.com | ---                                                                                   |
-|    Hain    | ---                      | JavaScript: [Metrakit/hain-plugin-meme](https://github.com/Metrakit/hain-plugin-meme) |
-|    Web     | ---                      | Clojure: [jasich/mighty-fine-memes](https://github.com/jasich/mighty-fine-memes)      |
-| Web, Slack | https://memecomplete.com | ---                                                                                   |
-|  Discord   | ---                      | JavaScript: https://github.com/parshsee/discordbot                                    |
+| Platforms  | Link                       | Source                                                                                |
+| :--------: | :------------------------- | :------------------------------------------------------------------------------------ |
+|   Slack    | ---                        | Python: [nicolewhite/slack-meme](https://github.com/nicolewhite/slack-meme)           |
+|   Slack    | ---                        | Go: [CptSpaceToaster/slackbot](https://github.com/CptSpaceToaster/slackbot)           |
+|   Slack    | <http://www.memetizer.com> | ---                                                                                   |
+|    Hain    | ---                        | JavaScript: [Metrakit/hain-plugin-meme](https://github.com/Metrakit/hain-plugin-meme) |
+|    Web     | ---                        | Clojure: [jasich/mighty-fine-memes](https://github.com/jasich/mighty-fine-memes)      |
+| Web, Slack | <https://memecomplete.com> | ---                                                                                   |
+|  Discord   | ---                        | JavaScript: [parshsee/discordbot](https://github.com/parshsee/discordbot)             |
 
 Additional clients can be found by searching for [code examples on GitHub](https://github.com/search?o=desc&q=%22memegen.link%22+&ref=searchresults&s=indexed&type=Code&utf8=%E2%9C%93).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ An API to programatically generate memes based solely on requested URLs.
 [![Coverage Status](http://img.shields.io/coveralls/jacebrowning/memegen/main.svg)](https://coveralls.io/r/jacebrowning/memegen)
 [![Swagger Validator](https://img.shields.io/swagger/valid/3.0?label=docs&specUrl=https%3A%2F%2Fapi.memegen.link%2Fdocs%2Fswagger.json)](https://api.memegen.link/docs/) <!--content-->
 [![License](https://img.shields.io/badge/license-mit-blue)](https://github.com/jacebrowning/memegen/blob/main/LICENSE.txt)
-[![GitHub Sponsora](https://img.shields.io/badge/server%20costs-%2412%2Fmonth-red)](https://github.com/sponsors/jacebrowning)
+[![GitHub Sponsors](https://img.shields.io/badge/server%20costs-%2412%2Fmonth-red)](https://github.com/sponsors/jacebrowning)
+
+Read the latest documentation [here](https://jacebrowning.github.io/memegen).
 
 ## Generating Images
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ An API to programatically generate memes based solely on requested URLs.
 [![License](https://img.shields.io/badge/license-mit-blue)](https://github.com/jacebrowning/memegen/blob/main/LICENSE.txt)
 [![GitHub Sponsora](https://img.shields.io/badge/server%20costs-%2412%2Fmonth-red)](https://github.com/sponsors/jacebrowning)
 
-# Generating Images
+## Generating Images
 
 The API is stateless so URLs contain all the information necessary to generate meme images. For example, <https://api.memegen.link/images/buzz/memes/memes_everywhere.png> produces:
 
 ![Sample Image](https://api.memegen.link/images/buzz/memes/memes_everywhere.png?&width=600)
 
-## Special Characters
+### Special Characters
 
 In URLs, spaces can be inserted using underscores or dashes:
 
@@ -36,7 +36,7 @@ For example, <https://api.memegen.link/images/doge/~hspecial_characters~q/unders
 
 ![Escaped Characters](https://api.memegen.link/images/doge/~hspecial_characters~q/underscore__-dash--.png?&width=600)
 
-## Alternate Styles
+### Alternate Styles
 
 Some memes come in multiple forms, which can be selected via `?style=<style>`.
 
@@ -46,13 +46,13 @@ For example, these are two styles provided by the <https://api.memegen.link/temp
 | :---------------------------------------------------: | :--------------------------------------------------------------: |
 | ![](https://api.memegen.link/images/ds.png?width=280) | ![](https://api.memegen.link/images/ds.png?style=maga&width=280) |
 
-## Custom Backgrounds
+### Custom Backgrounds
 
 You can also use your own image URL as the background. For example, <https://api.memegen.link/images/custom/_/my_background.png?background=http://www.gstatic.com/webp/gallery/1.png> produces:
 
 ![Custom Background](https://api.memegen.link/images/custom/_/my_background.png?background=http://www.gstatic.com/webp/gallery/1.png&width=600)
 
-## Image Sizing
+### Image Sizing
 
 Images can be scaled to a specific width via `?width=<int>` or a specific height via `?height=<int>`. If both parameters are provided (`?width=<int>&height=<int>`), the image will be padded to the exact dimensions.
 
@@ -62,7 +62,7 @@ For example, <https://api.memegen.link/images/both/width_or_height/why_not_both~
 
 Clients can also request `.jpg` instead of `.png` for smaller files.
 
-## Live Previews
+### Live Previews
 
 If your client is going to show live previews of a custom meme, please use the `/images/preview.jpg` endpoint, which accepts URL-encoded parameters and returns smaller images to minimize bandwidth.
 
@@ -71,9 +71,11 @@ Both template keys and URLs are supported:
 - <https://api.memegen.link/images/preview.jpg?template=fry&line[]=first&line[]=second>
 - <https://api.memegen.link/images/preview.jpg?template=https://api.memegen.link/images/fry.png&line[]=first&line[]=second>
 
-# API Documentation
+## API Documentation
 
 The full interactive API documentation is available here: <https://api.memegen.link/docs/>
+
+### Sample Clients
 
 Here are some sample clients to explore:
 

--- a/app/views.py
+++ b/app/views.py
@@ -20,7 +20,7 @@ jinja = SanicJinja2(app, pkg_name="app")
 async def index(request):
     html = markdown(
         text=Path("README.md").read_text(),
-        extensions=["pymdownx.magiclink", "markdown.extensions.tables"],
+        extensions=["markdown.extensions.tables"],
     )
     html = html.replace("<code></code>", "<code>&nbsp</code>")
     html = html.replace(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ ipdb = "*"
 rope = "^0.14.0"
 watchdog = { version = "*", extras = ["watchmedo"] }
 
+# Documentation
+portray = "^1.4.0"
+
 [tool.black]
 
 quiet = true
@@ -81,6 +84,16 @@ addopts = """
 """
 
 cache_dir = ".cache"
+
+[tool.portray]
+modules = ["app"]
+extra_dirs = ["app/static"]
+
+[tool.portray.mkdocs.theme]
+name = "material"
+logo = "app/static/favicon.ico"
+favicon = "app/static/favicon.ico"
+palette = {primary = "blue grey", accent = "pink"}
 
 [build-system]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ sanic-jinja2 = "~0.8.0"
 
 # Markdown
 markdown = "~3.2.2"
-pymdown-extensions = "^8.0"
 pygments = "^2.7.0"
 
 # Images
@@ -88,6 +87,9 @@ cache_dir = ".cache"
 [tool.portray]
 modules = ["app"]
 extra_dirs = ["app/static"]
+
+# [tool.portray.mkdocs]
+# markdown_extensions = ["pymdownx.magiclink"]
 
 [tool.portray.mkdocs.theme]
 name = "material"


### PR DESCRIPTION
Hey Jace,

Not sure if you've seen it before but I recently came across a neat project called portray (here's the [repo](https://github.com/timothycrosley/portray) and the [docs](https://timothycrosley.github.io/portray/)). It's a really slick tool that helps present documentation in a modern way with minimal configuration (see the pyproject.toml diff). The thing I love about it is how easy it makes it to deploy and maintain the docs on GitHub Pages (see the Makefile for the commands). I've deployed it on my fork if you'd like to see it in action: https://kyluca.github.io/memegen/

![screenshot_from_2020_10_29_20_37_43](https://user-images.githubusercontent.com/17324842/97558060-52323180-1a27-11eb-93d6-f7b87c41d4b6.png)

I know you've already got the readme displayed at https://api.memegen.link/, so the main differences with this are it automatically pulls in the other Markdown files like the contributing guide, changelog, and auto-generated reference docs from the code docstrings etc.

Let me know what you think :smile:

Cheers,
Kyle
