### PR TITLE
Make uploading coverage optional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,11 @@ jobs:
 
       - run:
           name: Running tests
-          command: make test && sudo pip install coveralls && coveralls
+          command: make test
+
+      - run:
+          name: Uploading coverage
+          command: sudo pip install coveralls && coveralls || true
 
       - store_test_results:
           path: results


### PR DESCRIPTION
Coveralls seems to fail on forks, see: https://app.circleci.com/pipelines/github/jacebrowning/memegen/593/workflows/89e182b1-b48c-42ec-8d4d-d5e84f39bce0/jobs/605