### PR TITLE
Reduce WebP file to 1/10 of original size

### DIFF
--- a/app/utils/images.py
+++ b/app/utils/images.py
@@ -105,7 +105,7 @@ def save(
             template, style, lines, size, font_name, maximum_frames, watermark=watermark
         )
         fps = (duration // len(frames)) // 1.5  # TODO: Match GIF framerate
-        webp.save_images(frames, path, fps=fps, lossless=True)
+        webp.save_images(frames, path, fps=fps, lossless=False)
     else:
         image = render_image(
             template, style, lines, size, font_name, watermark=watermark


### PR DESCRIPTION
This greatly improves performance while reducing file size drastically. GIFs being the source of the animation and somewhat low quality means the output isn't noticeably affected.