### PR TITLE
Fix the GitHub link

### DIFF
--- a/docs/theme/main.html
+++ b/docs/theme/main.html
@@ -43,7 +43,7 @@
 {% block next_prev %} {% endblock %} {% block repo %}
 
 <li class="nav-item">
-    <a href="https://api.memegen.link/docs/" class="nav-link">
+    <a href="https://github.com/jacebrowning/memegen" class="nav-link">
         <i class="fa-brands fa-github"></i>
         GitHub
     </a>


### PR DESCRIPTION
The link "GitHub" previously led to the Swagger docs.