### PR TITLE
docs: add unified URL-construction guide and OpenAPI enrichments (#993)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,6 @@ This can be combined with [custom overlays](#custom-overlays) to augment the bac
 
 <br><hr><br>
 
-For the full URL-construction reference (the four load-bearing template fields, the escape table, all rendering query parameters, and notes for automated clients), see [`docs/guide.md`](docs/guide.md).
+For the full URL-construction reference (the four load-bearing template fields, the escape table, all rendering query parameters, and notes for automated clients), see [`docs/guide.md`](https://github.com/jacebrowning/memegen/blob/main/docs/guide.md).
 
 Explore the full API here: <https://api.memegen.link/docs/>

--- a/README.md
+++ b/README.md
@@ -144,4 +144,6 @@ This can be combined with [custom overlays](#custom-overlays) to augment the bac
 
 <br><hr><br>
 
+For the full URL-construction reference (the four load-bearing template fields, the escape table, all rendering query parameters, and notes for automated clients), see [`docs/guide.md`](docs/guide.md).
+
 Explore the full API here: <https://api.memegen.link/docs/>

--- a/app/config.py
+++ b/app/config.py
@@ -110,6 +110,58 @@ def init(app: Sanic):
 
         View the image: <https://api.memegen.link/images/aag/foo/bar.png>
 
+        For the full URL-construction reference, see [`docs/guide.md`](https://github.com/jacebrowning/memegen/blob/main/docs/guide.md).
+
+        <details>
+        <summary>URL anatomy</summary>
+
+        A rendered meme URL has the form:
+
+        ```
+        /images/{template_id}/{line_1}/{line_2}/.../{line_n}.{ext}
+        ```
+
+        where `n` is at most the template's `lines` value, and `{ext}` is one of `png`, `jpg`, `gif`, or `webp`. Trailing lines may be omitted; pass `_` to render an empty line in a non-trailing position. The blank template is at `/images/{template_id}.{ext}`.
+
+        The four template-metadata fields that govern URL construction are `id`, `lines`, `overlays`, and `styles`. The remaining fields are descriptive.
+        </details>
+
+        <details>
+        <summary>Special characters</summary>
+
+        | Character | Escape |
+        |-----------|--------|
+        | Space | `_` |
+        | Underscore | `__` |
+        | Newline | `~n` |
+        | `?` | `~q` |
+        | `&` | `~a` |
+        | `%` | `~p` |
+        | `#` | `~h` |
+        | `/` | `~s` |
+        | `\\` | `~b` |
+        | `<` | `~l` |
+        | `>` | `~g` |
+        | `"` | `''` |
+
+        Emoji are supported via shortcode aliases (e.g. `:thumbsup:`). Alternatively, `POST` to `/images/` with raw text and use the canonical `url` field from the response.
+        </details>
+
+        <details>
+        <summary>Rendering options</summary>
+
+        These query parameters apply to all path-based image endpoints:
+
+        - `style=<name>` — alternate visual variant from the template's `styles` array; also accepts an HTTPS URL for a custom overlay
+        - `font=<name>` — override the template's default font; full list at `/fonts/`
+        - `layout=top` — place all text at the top
+        - `width=<int>`, `height=<int>` — output dimensions in pixels
+        - `color=<text>,<outline>` — HTML color names or hex codes
+        - `background=<url>` — custom background image
+        - `center=<x>,<y>`, `scale=<float>` — overlay placement modifiers (when `overlays > 0`)
+        - `frames=<int>` — cap on rendered frames for animated output (`gif`/`webp`); `0` (default) means no cap
+        </details>
+
         ## Links
         """.replace("https://api.memegen.link", settings.BASE_URL)),
     )

--- a/app/views/fonts.py
+++ b/app/views/fonts.py
@@ -10,6 +10,12 @@ blueprint = Blueprint("Fonts", url_prefix="/fonts")
 
 @blueprint.get("/")
 @openapi.summary("List available fonts")
+@openapi.description(
+    "List of fonts available for the `font=` query parameter on path-based "
+    "image endpoints. Each entry has an `id` (canonical name) and an "
+    "optional `alias`. Named aliases include `thick`, `comic`, `he` "
+    "(Hebrew), and `jp` (Japanese)."
+)
 @openapi.response(
     200,
     {"application/json": list[FontResponse]},

--- a/app/views/images.py
+++ b/app/views/images.py
@@ -40,6 +40,23 @@ async def index(request: Request):
 
 @blueprint.post("/")
 @openapi.summary("Create a meme from a template")
+@openapi.description(
+    "Create a meme by `POST`ing raw text. The response includes a `url` "
+    "field containing the canonical, escape-encoded URL — agents that don't "
+    "want to implement the escape table client-side should use this endpoint "
+    "and read back the URL rather than constructing one themselves.\n\n"
+    "Body fields:\n"
+    "- `template_id`: ID of the template to render (from `GET /templates/`).\n"
+    "- `text`: Lines of text in order (raw, not escape-encoded). Up to the "
+    "template's `lines` value; pass an empty string for an empty intermediate "
+    "line.\n"
+    "- `style`: One or more style names from the template's `styles` array, "
+    "or HTTPS URLs to use as custom overlay images. For templates with "
+    "`overlays > 1`, the array sets each slot independently.\n"
+    "- `extension`: Output format — `png`, `jpg`, `gif`, or `webp`.\n"
+    "- `redirect`: If true, returns 302 to the canonical URL instead of "
+    "returning JSON."
+)
 @openapi.body({"application/json": MemeRequest})
 @openapi.response(
     201, {"application/json": MemeResponse}, "Successfully created a meme"
@@ -147,7 +164,115 @@ async def index_custom(request: Request):
     "template_filename",
     str,
     "path",
-    description="Template ID and image format: `<template_id>.<extension>`",
+    description=(
+        "Template ID and image format: `<template_id>.<extension>`. This is "
+        "the canonical empty-template render and matches the `blank` field on "
+        "`GET /templates/{id}`. Use this when a client just wants the "
+        "background. The same query parameters as "
+        "`/images/{template_id}/{text_filepath}` apply."
+    ),
+)
+@openapi.parameter(
+    "style",
+    str,
+    "query",
+    description=(
+        "Alternate visual variant from the template's `styles` array, OR an "
+        "HTTPS URL to use as a custom overlay image. For templates with "
+        "`overlays > 1`, may be repeated to set each slot independently. "
+        "Unknown style names return HTTP 422, not the default render."
+    ),
+)
+@openapi.parameter(
+    "font",
+    str,
+    "query",
+    description=(
+        "Font name or alias overriding the template's default. Full list at "
+        "`/fonts/`. Named aliases: `thick`, `comic`, `he`, `jp`. Unknown "
+        "values return HTTP 422; the image still renders with the template's "
+        "default font."
+    ),
+)
+@openapi.parameter(
+    "layout",
+    str,
+    "query",
+    description=(
+        "`default` (implicit) or `top`. `top` places all text at the image "
+        "top rather than the template's default regions."
+    ),
+)
+@openapi.parameter(
+    "width",
+    int,
+    "query",
+    description=(
+        "Output width in pixels. If both `width` and `height` are supplied, "
+        "the image is padded to fit while preserving aspect ratio. Values "
+        "between 1 and 9 are rejected with HTTP 422."
+    ),
+)
+@openapi.parameter(
+    "height",
+    int,
+    "query",
+    description="Output height in pixels. See `width` for combined behavior.",
+)
+@openapi.parameter(
+    "color",
+    str,
+    "query",
+    description=(
+        "Comma-separated `<text>,<outline>` pair. Each value is either an "
+        "HTML color name or a hex code (with or without a leading `#`). "
+        "Example: `white,black`."
+    ),
+)
+@openapi.parameter(
+    "background",
+    str,
+    "query",
+    description=("Custom background image URL. Composes with `style=<url>` overlays."),
+)
+@openapi.parameter(
+    "center",
+    str,
+    "query",
+    description=(
+        "Comma-separated `<x>,<y>` fractional coordinates (0.0–1.0) for "
+        "overlay center within its slot. Most useful with `style=<url>`."
+    ),
+)
+@openapi.parameter(
+    "scale",
+    float,
+    "query",
+    description=(
+        "Multiplier applied to the overlay's default size. Most useful with "
+        "`style=<url>`."
+    ),
+)
+@openapi.parameter(
+    "frames",
+    int,
+    "query",
+    description=(
+        "Maximum number of frames to render in animated output (`gif`/"
+        "`webp`). 0 (default) means no cap. Use this to bound response size "
+        "and render time on long animations."
+    ),
+)
+@openapi.parameter(
+    "status",
+    int,
+    "query",
+    description=(
+        "Override the HTTP response status code. Primarily used internally "
+        "by the `POST /images/` → redirect flow to propagate a `201 Created` "
+        "semantic to the final image fetch. Most clients should not need to "
+        "set this directly."
+    ),
 )
 @openapi.response(
     200, {"image/*": bytes}, "Successfully displayed a template background"
@@ -184,9 +309,123 @@ async def detail_blank(request: Request, template_filename: str):
     "text_filepath",
     str,
     "path",
-    description="Lines of text and image format: `<line1>/<line2>.<extension>`",
+    description=(
+        "Lines of text and image format: `<line1>/<line2>/.../<line_n>."
+        "<extension>`, where `n` ≤ the template's `lines` value. Trailing "
+        "lines may be omitted; pass `_` (single underscore) for an empty "
+        "intermediate line. Extensions: `png`, `jpg`, `gif`, `webp`. Special "
+        "characters in each segment use an ASCII-safe escape table: `_` "
+        "(space), `__` (literal underscore), `~n` (newline), `~q` (?), `~a` "
+        "(&), `~p` (%), `~h` (#), `~s` (/), `~b` (\\), `~l` (<), `~g` (>), "
+        "`''` (double quote). Emoji shortcodes (e.g. `:thumbsup:`) are "
+        "substituted automatically. Clients that don't want to implement the "
+        "escape table should `POST` to `/images/` with raw text in the JSON "
+        "body and use the canonical `url` field from the response."
+    ),
 )
 @openapi.parameter("template_id", str, "path", description="ID of a meme template")
+@openapi.parameter(
+    "style",
+    str,
+    "query",
+    description=(
+        "Alternate visual variant from the template's `styles` array, OR an "
+        "HTTPS URL to use as a custom overlay image. For templates with "
+        "`overlays > 1`, may be repeated to set each slot independently. "
+        "Unknown style names return HTTP 422, not the default render."
+    ),
+)
+@openapi.parameter(
+    "font",
+    str,
+    "query",
+    description=(
+        "Font name or alias overriding the template's default. Full list at "
+        "`/fonts/`. Named aliases: `thick`, `comic`, `he`, `jp`. Unknown "
+        "values return HTTP 422; the image still renders with the template's "
+        "default font."
+    ),
+)
+@openapi.parameter(
+    "layout",
+    str,
+    "query",
+    description=(
+        "`default` (implicit) or `top`. `top` places all text at the image "
+        "top rather than the template's default regions."
+    ),
+)
+@openapi.parameter(
+    "width",
+    int,
+    "query",
+    description=(
+        "Output width in pixels. If both `width` and `height` are supplied, "
+        "the image is padded to fit while preserving aspect ratio. Values "
+        "between 1 and 9 are rejected with HTTP 422."
+    ),
+)
+@openapi.parameter(
+    "height",
+    int,
+    "query",
+    description="Output height in pixels. See `width` for combined behavior.",
+)
+@openapi.parameter(
+    "color",
+    str,
+    "query",
+    description=(
+        "Comma-separated `<text>,<outline>` pair. Each value is either an "
+        "HTML color name or a hex code (with or without a leading `#`). "
+        "Example: `white,black`."
+    ),
+)
+@openapi.parameter(
+    "background",
+    str,
+    "query",
+    description=("Custom background image URL. Composes with `style=<url>` overlays."),
+)
+@openapi.parameter(
+    "center",
+    str,
+    "query",
+    description=(
+        "Comma-separated `<x>,<y>` fractional coordinates (0.0–1.0) for "
+        "overlay center within its slot. Most useful with `style=<url>`."
+    ),
+)
+@openapi.parameter(
+    "scale",
+    float,
+    "query",
+    description=(
+        "Multiplier applied to the overlay's default size. Most useful with "
+        "`style=<url>`."
+    ),
+)
+@openapi.parameter(
+    "frames",
+    int,
+    "query",
+    description=(
+        "Maximum number of frames to render in animated output (`gif`/"
+        "`webp`). 0 (default) means no cap. Use this to bound response size "
+        "and render time on long animations."
+    ),
+)
+@openapi.parameter(
+    "status",
+    int,
+    "query",
+    description=(
+        "Override the HTTP response status code. Primarily used internally "
+        "by the `POST /images/` → redirect flow to propagate a `201 Created` "
+        "semantic to the final image fetch. Most clients should not need to "
+        "set this directly."
+    ),
+)
 @openapi.response(200, {"image/*": bytes}, "Successfully displayed a custom meme")
 @openapi.response(404, {"image/*": bytes}, "Template not found")
 @openapi.response(414, {"image/*": bytes}, "Custom text too long (length >200)")

--- a/app/views/templates.py
+++ b/app/views/templates.py
@@ -14,6 +14,19 @@ blueprint = Blueprint("Templates", url_prefix="/templates")
 
 @blueprint.get("/")
 @openapi.summary("List all templates")
+@openapi.description(
+    "The full list of renderable templates. For URL construction, the four "
+    "load-bearing fields per template are `id` (goes into the path after "
+    "`/images/`), `lines` (maximum number of `/`-separated text segments "
+    "accepted in the path), `overlays` (number of overlay image slots the "
+    "template defines), and `styles` (allowed values for the `style=` query "
+    "parameter). The remaining fields are descriptive: `name` for display, "
+    "`blank` for the empty-template render URL, `example.url` for a "
+    "guaranteed-valid smoke-test URL, `source` for attribution, and "
+    "`keywords` for search. Recommended client pattern: fetch this endpoint "
+    "once at startup, cache, and construct URLs locally rather than per-meme. "
+    "See `docs/guide.md` for worked examples and the full escape table."
+)
 @openapi.parameter(
     "animated",
     bool,
@@ -39,6 +52,13 @@ async def index(request: Request):
 
 @blueprint.get("/<id:slug>")
 @openapi.summary("View a specific template")
+@openapi.description(
+    "Per-template metadata. The four URL-construction fields are `id`, "
+    "`lines`, `overlays`, and `styles`; see `GET /templates/` for what each "
+    "one governs and `docs/guide.md` for worked examples. The `example.url` "
+    "field is a guaranteed-valid render URL — issuing a `HEAD` against it is "
+    "the cheapest way to validate that the template id is live."
+)
 @openapi.parameter("id", str, "path", description="ID of a meme template")
 @openapi.response(
     200,

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,201 @@
+# Constructing meme URLs
+
+A reference for humans and automated clients on how to build valid memegen URLs from template metadata. The goal is a single page you can read top-to-bottom and emit a correct URL on the first try, without consulting the README, the OpenAPI spec, and a per-template metadata response separately.
+
+The OpenAPI specification at [`/docs/openapi.json`](https://api.memegen.link/docs/openapi.json) is the source of truth for endpoint shapes and parameter names. This guide is derived from those descriptions and adds worked examples, edge-case behavior, and a recipe for automated clients that doesn't fit cleanly inside the spec itself.
+
+## The shape of a meme URL
+
+A rendered meme URL has the form:
+
+```
+https://api.memegen.link/images/{template_id}/{line_1}/{line_2}/.../{line_n}.{ext}
+```
+
+where `{template_id}` is the `id` field from `/templates/`, each `{line_i}` is one segment of text escaped per the rules below, `n` is at most the template's `lines` value, and `{ext}` is one of `png`, `jpg`, `gif`, or `webp`. A blank template (no text) is available at `/images/{template_id}.{ext}` — this is the value of the `blank` field on the template's metadata response.
+
+## Source of truth: the templates endpoint
+
+`GET /templates/` returns the full list of renderable templates. Each entry has the form:
+
+```json
+{
+  "id": "ds",
+  "name": "Daily Struggle",
+  "lines": 3,
+  "overlays": 1,
+  "styles": ["default", "maga"],
+  "blank": "https://api.memegen.link/images/ds.jpg",
+  "example": {
+    "text": ["The dress is black and blue.", "The dress is gold and white."],
+    "url": "https://api.memegen.link/images/ds/The_dress_is_black_and_blue./The_dress_is_gold_and_white..jpg"
+  },
+  "source": "https://knowyourmeme.com/memes/daily-struggle",
+  "keywords": []
+}
+```
+
+For URL construction, four fields are load-bearing:
+
+| Field | Role in the URL |
+|-------|-----------------|
+| `id` | Goes into the path immediately after `/images/` |
+| `lines` | Maximum number of `/`-separated text segments accepted in the path |
+| `overlays` | Number of overlay image slots the template defines |
+| `styles` | Allowed values for the `style=` query parameter |
+
+The remaining fields (`name`, `blank`, `example`, `source`, `keywords`) are descriptive — useful for discovery, search, and validation, but not for URL construction.
+
+For automated clients, the recommended bootstrap is to fetch `/templates/` once at startup, cache it, and construct URLs locally. Refresh on a long interval; the template list is stable.
+
+## Path segments and the `lines` field
+
+The number of `/`-separated text segments after `{template_id}` may range from zero (the blank template) up to the template's `lines` value. Trailing lines may be omitted; to skip an earlier line while populating a later one, pass an underscore (`_`) as the segment to render an empty line in that position.
+
+For example, on the Ancient Aliens Guy template (`aag`, `lines: 2`):
+
+```
+/images/aag/aliens.png            -> top line "aliens", bottom line empty
+/images/aag/_/aliens.png          -> top line empty, bottom line "aliens"
+/images/aag/why/aliens.png        -> both lines populated
+```
+
+If you pass more segments than `lines`, the surplus is currently ignored. Agents should treat over-passing as an error and trim to `template.lines` before constructing the URL rather than relying on silent truncation as a contract.
+
+## Escaping text segments
+
+Text segments live inside a URL path, so a small escape table substitutes ASCII-safe sequences for characters that would otherwise need percent-encoding or break path parsing:
+
+| Character | Escape |
+|-----------|--------|
+| Space | `_` |
+| Underscore | `__` |
+| Newline | `~n` |
+| `?` | `~q` |
+| `&` | `~a` |
+| `%` | `~p` |
+| `#` | `~h` |
+| `/` | `~s` |
+| `\` | `~b` |
+| `<` | `~l` |
+| `>` | `~g` |
+| `"` | `''` |
+
+Emoji are supported via shortcode aliases — for example, `:thumbsup:` renders 👍.
+
+If you'd rather not implement the escape table client-side, `POST` to `/images/` with a JSON body containing `template_id` and a `text` array of raw strings. The response includes a `url` field with the canonical, escaped URL. Automated clients can `POST` raw text and use the returned URL verbatim instead of maintaining the escape table themselves.
+
+## Styles and the `styles` field
+
+Many templates support visual variants, exposed via the `styles` field on `/templates/{id}`. Selection is via the `style=` query parameter:
+
+```
+/images/ds/The_dress_is_black_and_blue./The_dress_is_gold_and_white..jpg?style=maga
+```
+
+The default style is implicit when `style=` is omitted.
+
+The `style=` parameter has a second mode: passing an HTTPS URL instead of a name treats the URL as a custom overlay image and composites it onto the template. This dual purpose — named style or arbitrary overlay URL — is easy to miss when reading the spec. For templates with `overlays > 1`, supply multiple `style=` values to set each overlay slot independently.
+
+## Overlays
+
+A template's `overlays` field counts the compositing slots the template defines — for example, the Drake template defines two regions where reaction images go. When `overlays > 0`, each slot can be filled either with the template's default content (no `style=` needed) or with a custom image URL via `style=<url>`.
+
+Two query parameters fine-tune overlay placement, most useful when supplying custom images:
+
+- `center=<x>,<y>` — fractional coordinates (0.0–1.0) for the overlay center within its slot
+- `scale=<float>` — multiplier applied to the overlay's default size
+
+## Rendering options
+
+The following query parameters apply to all path-based image endpoints. Combining them is allowed; later parameters compose with the path-derived defaults.
+
+### Format
+
+The file extension on the path determines the response format. `png` and `jpg` are static. `gif` and `webp` produce animated output when the template's background is animated, and a static-background-with-animated-text variant otherwise.
+
+### Dimensions
+
+`width=<int>` and `height=<int>` set the output dimensions in pixels. If both are supplied, the image is padded to fit while preserving aspect ratio. Values between 1 and 9 are rejected as too small (the size is silently set back to 0,0 and the response status is 422).
+
+### Layout
+
+`layout=top` places all text at the top of the image rather than spreading it across the template's default text regions. The `default` layout is implicit when `layout=` is omitted.
+
+### Font
+
+`font=<name>` overrides the template's default font. The full list of available fonts is at `GET /fonts/`. Named aliases include `thick`, `comic`, `he` (Hebrew), and `jp` (Japanese).
+
+### Color
+
+`color=<text>,<outline>` is a comma-separated pair, each value either an HTML color name or a hex code. Hex codes may be supplied with or without a leading `#`. Example: `color=white,black`.
+
+### Custom background
+
+`background=<url>` uses an arbitrary image as the template background. It composes with `style=<url>` overlays as expected.
+
+### Animation frames
+
+`frames=<int>` caps the number of frames rendered in animated output (`gif`/`webp`). The default of `0` means no cap. Use this to bound response size and render time on long animations.
+
+### Status override
+
+`status=<int>` overrides the HTTP response status code on the rendered image. This is primarily used internally by the `POST /images/` → redirect flow to propagate a `201 Created` semantic to the final image fetch. Most clients should not need to set this directly.
+
+## Worked examples
+
+A few complete URLs covering common cases:
+
+```
+# Two-line meme on a standard template
+https://api.memegen.link/images/aag/Why_can''t/I_post_memes.png
+
+# Non-default style
+https://api.memegen.link/images/ds/Wikipedia_says_no/My_LLM_says_yes.jpg?style=maga
+
+# Custom dimensions and font
+https://api.memegen.link/images/aag/agile/standups.png?width=800&font=thick
+
+# Empty top line (skip the first segment)
+https://api.memegen.link/images/aag/_/aliens.png
+
+# Multi-line text via newline escape
+https://api.memegen.link/images/aag/first_line~nsecond_line/bottom.png
+
+# Custom background
+https://api.memegen.link/images/custom/top_text/bottom_text.png?background=https://example.com/img.jpg
+```
+
+## Notes for automated clients
+
+A handful of points that are obvious in retrospect but cost an agent several round-trips to discover:
+
+1. **Bootstrap once, cache.** `GET /templates/` is the single source of truth for renderable templates. Fetch at startup and refresh on a long interval; don't query per-meme.
+2. **`POST` raw, read back the URL.** All `POST` endpoints normalize special characters into the escape forms above and return the canonical URL in the `url` field. Agents that don't want to maintain the escape table client-side can `POST` raw strings and use the returned URL verbatim.
+3. **`example.url` is a free smoke test.** Each template's `example.url` is guaranteed to render, so a `HEAD` request against that URL is the cheapest way to validate that a `template_id` is live before constructing a derived URL.
+4. **Validate `style` against `template.styles`.** Passing an unknown style name returns HTTP 422, not a default render, so client-side validation prevents user-visible errors. Likewise, validate `font=` against `GET /fonts/` before sending — an unknown font also returns 422.
+5. **Trim text segments to `lines`.** Don't rely on silent truncation; trim client-side to `template.lines` before joining.
+
+## Edge cases
+
+| Situation | Current behavior |
+|-----------|------------------|
+| More text segments than `lines` | Extra segments are ignored; the meme renders with the first `lines` segments |
+| Fewer text segments than `lines` | Missing trailing lines render as empty |
+| Unknown `style=` name (not a URL) | Returns HTTP 422 |
+| Unknown `font=` value | Returns HTTP 422; the image still renders using the template's default font |
+| Path text segment >200 bytes | Returns HTTP 414 (`Custom text too long`) |
+| Unknown image extension | Defaults to PNG, returns HTTP 422 |
+| `width` or `height` between 1 and 9 | Returns HTTP 422 (size silently set back to 0,0) |
+| Unknown `template_id` | Returns HTTP 404 |
+| `style=<url>` that can't be downloaded | Returns HTTP 415 |
+| `id=custom` with no or un-downloadable `background=` URL | Returns HTTP 422 (missing) or HTTP 415 (un-downloadable) |
+| Invalid `color=` value | Returns HTTP 422 |
+
+## Reference
+
+- Templates list — `GET /templates/`
+- Per-template metadata — `GET /templates/{id}`
+- Fonts — `GET /fonts/`
+- OpenAPI spec — [`/docs/openapi.json`](https://api.memegen.link/docs/openapi.json)
+- Interactive client — [`/docs`](https://api.memegen.link/docs)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ edit_uri: ""
 
 nav:
   - Home: index.md
+  - Guide: guide.md
   - Clients: clients.md
   - Examples: examples.md
 


### PR DESCRIPTION
Closes #993.

## Summary

Adds a single canonical reference for building memegen URLs from template metadata, in two surfaces:

1. **OpenAPI spec enrichment** so agents that ground on `openapi.json` can construct a valid URL without leaving the spec.
2. **`docs/guide.md`** as a long-form walkthrough for humans, with worked examples and edge-case notes that don't fit cleanly inside parameter descriptions.

Both surfaces draw on the same underlying rules (path-to-`lines` mapping, escape table, query-parameter semantics) so they don't drift.

## What's in this PR

- **`docs/guide.md`** (new) — full reference covering URL anatomy, the four load-bearing template fields (`id`, `lines`, `overlays`, `styles`), the special-character escape table, all rendering query parameters, worked examples, an automated-clients section, and an edge-case table. Wired into `mkdocs.yml` `nav` so it ships with the published docs site.
- **OpenAPI metadata enrichments**:
  - Three collapsed `<details>` blocks added to `info.description` (URL anatomy, special characters, rendering options) below the existing two examples, so the interactive client stays above the fold on `/docs`.
  - New `@openapi.description(...)` text on `GET /templates/`, `GET /templates/{id}`, `GET /fonts/`, and `POST /images/`.
  - Expanded `text_filepath` and `template_filename` path-parameter descriptions.
  - **Eleven query parameters** added to the path-based image endpoints (`style`, `font`, `layout`, `width`, `height`, `color`, `background`, `center`, `scale`, `frames`, `status`) — none of which were previously in the spec.
- **`README.md` pointer** to `docs/guide.md` in the trailing reference section. No content duplicated.

## Behavior changes

None. Documentation-only — every change is doc/metadata. Existing clients continue to work without modification.

## Verified behaviors

Before locking documentation in, I traced the four open behaviors from the issue plus one I noticed in passing against the actual source. Two contradicted the original draft and the documentation was updated to match the code:

| Behavior | Source verdict | File |
|---|---|---|
| Over-passing text segments → silently ignored | **Confirmed.** `lines` indexing only reads `0..template.lines-1`; extras dropped. | `app/utils/images.py:697-700` |
| Unknown `style=` name → falls back to default | **Wrong — returns HTTP 422.** `template.check()` returns False; non-URL non-placeholder values set `status = 422`. (URL-style values that fail `check` return 415.) | `app/views/helpers.py:209-214` |
| `color=<text>,<outline>` exists, comma-separated, HTML names or hex | **Confirmed.** Validator tries both `value` and `#value`, so hex codes work with or without `#`. | `app/views/helpers.py:193-203`, `app/utils/images.py:849-856` |
| Emoji shortcodes (`:thumbsup:` → 👍) | **Confirmed.** `emoji.emojize(text, language=\"alias\")` from the `emoji` PyPI package (transitive via `pilmoji`). | `app/models/text.py:91` |
| Unknown `font=` value | **Returns HTTP 422 even though the image still renders** with the template's default font. | `app/views/helpers.py:216-225` |

The guide's edge-case table and the OpenAPI parameter descriptions reflect the actual behavior in all five rows.

## Heads-up for the maintainer

The unknown-`font=` path returns HTTP 422 even though the rendered image is still served (template default font is used in place of the unknown one). This is documented as-is in the guide and the `font` parameter description. It's the kind of thing a client author might find surprising — flagging in case you'd like to revisit the contract in a follow-up. No code change in this PR.

## Open questions

- **Per-field schema descriptions on `MemeRequest`.** The body schemas in `app/views/schemas.py` are plain `@dataclass` classes, which can't carry per-field descriptions without converting to `Annotated`/`pydantic`. As a stopgap I documented the fields in the operation-level `@openapi.description(...)` on `POST /images/`. Happy to do the schema migration in a follow-up if you'd prefer real per-field metadata.
- **`status=<int>` query parameter.** Documented because it's accepted, but its primary purpose is internal POST→GET redirect plumbing. If you'd rather hide it from the spec entirely, that's a one-line revert of the relevant `@openapi.parameter` decorator.

## Verification done

- `python3 -m black --check` passes on all four touched Python files.
- AST/syntax checks pass on `app/config.py` and `app/views/{images,templates,fonts}.py`.
- Confirmed `sanic_ext.openapi.description` exists and the decorator stack composes cleanly (it wasn't used previously in this codebase, but it's a standard sanic-ext decorator).

## Verification still needed

These need a working dev environment, which I didn't have locally:

- `make test` (or `make test-fast`) to confirm no test inspects the OpenAPI payload in a way the new descriptions break.
- `make check` (mypy) on the touched files.
- Boot the server, fetch `/docs/openapi.json`, and confirm the new descriptions and parameters appear correctly.
- Open `/docs` in a browser and confirm the three `<details>` blocks render **collapsed by default** and the existing two examples remain above the fold.
- Smoke-test the four behaviors above with `curl` against the local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)