### PR TITLE
Only drop trailing blank lines when cleaning URLs

### DIFF
--- a/app/tests/test_utils_urls.py
+++ b/app/tests/test_utils_urls.py
@@ -1,0 +1,33 @@
+import pytest
+
+from .. import utils
+
+URL_CLEANED = [
+    # Trailing blank lines are dropped
+    (
+        "http://localhost:5000/images/iw/_.png",
+        "http://localhost:5000/images/iw.png",
+    ),
+    (
+        "http://localhost:5000/images/iw/a/_/_.png",
+        "http://localhost:5000/images/iw/a.png",
+    ),
+    (
+        "http://localhost:5000/images/iw/a/_.png?width=100",
+        "http://localhost:5000/images/iw/a.png?width=100",
+    ),
+    # A blank line followed by more text is preserved
+    (
+        "http://localhost:5000/images/vince/a/_.b/c_d.png",
+        "http://localhost:5000/images/vince/a/_.b/c_d.png",
+    ),
+    (
+        "http://localhost:5000/images/vince/a/_.b/c-d.png",
+        "http://localhost:5000/images/vince/a/_.b/c-d.png",
+    ),
+]
+
+
+@pytest.mark.parametrize(("url", "cleaned"), URL_CLEANED)
+def test_clean(expect, url, cleaned):
+    expect(utils.urls.clean(url)) == cleaned

--- a/app/utils/urls.py
+++ b/app/utils/urls.py
@@ -1,3 +1,4 @@
+import re
 from urllib.parse import unquote, urlencode
 
 from furl import furl
@@ -69,8 +70,7 @@ def clean(url: str) -> str:
     url = url.replace(" ", "_")
 
     # Drop trailing spaces
-    while "/_." in url:
-        url = url.replace("/_.", ".")
+    url = re.sub(r"(?:/_)+(\.\w+)(?=$|\?)", r"\1", url)
 
     # TODO: Fix Sanic bug?
     # https://github.com/jacebrowning/memegen/issues/799


### PR DESCRIPTION
Closes #871

`clean()` replaced every `/_.` in the URL with `.`, not just the trailing one, so `/images/vince/a/_.b/c-d.png` (where the second line is a blank line followed by text starting with a dot) collapsed to `/images/vince/a.b/c-d.png` and redirected to the wrong image. Anchoring the substitution to the extension at the end of the path removes only genuinely trailing blank lines.
